### PR TITLE
docs: archive Decision 16 (Workato HTTP bridge torn down, KAN-120)

### DIFF
--- a/docs/archive/16-mcp-http-bridge-and-workato-auth.md
+++ b/docs/archive/16-mcp-http-bridge-and-workato-auth.md
@@ -1,5 +1,9 @@
 # 16 - MCP HTTP Bridge and Workato Authentication Model
 
+> **ARCHIVED 2026-05-20:** Workato access lost and the Cloud Run service `reporium-mcp-http` has been deleted.
+> The two-token auth scheme (`X-MCP-Token` outer, `X-App-Token` inner) is no longer in effect.
+> Document retained for historical reference; do not treat as current architecture.
+
 One decision about how the Reporium MCP tool suite is exposed to external orchestrators — in particular Workato — when those orchestrators cannot speak the stdio MCP transport directly.
 
 ---


### PR DESCRIPTION
## Summary

Archives Decision 16 (MCP HTTP bridge + Workato two-token auth). The architecture documented in this ADR is no longer in effect:

- Cloud Run service `reporium-mcp-http` deleted in parallel with this change
- Workato access lost 2026-05-20; recipe repo archived
- Two-token scheme (`X-MCP-Token` outer, `X-App-Token` inner) retired with the service
- Bridge secrets (`MCP_API_TOKEN`) retired

References KAN-120.

## Changes

- `git mv docs/16-mcp-http-bridge-and-workato-auth.md docs/archive/16-mcp-http-bridge-and-workato-auth.md`
- Prepended an `ARCHIVED 2026-05-20` blockquote at the top of the moved file, explaining the teardown and noting the doc is retained for historical reference only
- No README/index update needed — the index in `README.md` only lists Decisions 01-09, never enumerated 10-16

## Branch target

This repo has no `dev` branch (only `main`); PR opened against `main` as the only available target. **Do not auto-merge** — operator review required since main is the production target.

## Test plan

- [x] `git mv` performed with rename detected at 96% similarity
- [x] Blockquote uses `> **ARCHIVED 2026-05-20:**` format and explains the three teardown facts (Workato access lost, Cloud Run service deleted, auth scheme retired)
- [x] No internal links to the old path (`grep` confirmed: only the file itself referenced `16-mcp` / `Decision 16`)
- [ ] Markdown lint / CI checks pass on the rename