### PR TITLE
chore: OSS readiness (MIT license, contributing guide, badge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to reporium-system-design
+
+Thank you for your interest in contributing!
+
+## Branch Flow
+
+This repo follows GitFlow. All work happens on feature branches off the
+default branch (`main`), one feature or fix per branch.
+
+## Pull Requests
+
+1. Create a feature branch off `main`.
+2. Keep the branch scoped to a single feature or fix.
+3. Open a pull request into `main`.
+4. Ensure CI is green before requesting review.
+
+## Code Standards
+
+- No secrets or local machine paths in committed files.
+- Keep changes small and reviewable.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Perditio Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # reporium-system-design
 
+![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen)
+
 Architecture documentation, decision logs, and system diagrams for the Reporium platform.
 
 <!-- perditio-badges suite=Reporium workflow=test.yml -->


### PR DESCRIPTION
Part of the OSS-readiness epic perditioinc/reporium#425.

Changes: LICENSE CONTRIBUTING.md README-badge

- LICENSE: MIT, Copyright (c) 2026 Perditio Inc (if it was missing)
- CONTRIBUTING.md: short GitFlow guide adapted from reporium (if it was missing)
- README.md: MIT license badge (if it was missing)

Docs/license only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)