### PR TITLE
test(docs): harden doc-lint (dead links, decision headers, archived) + fix stale repo count

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Architecture documentation, decision logs, and system diagrams for the Reporium 
 ## Platform at a Glance
 
 ```
-  GitHub (826 repos)
+  GitHub (1,898 repos)
         |
         v
   +--------------+       +----------------+
@@ -43,7 +43,7 @@ Architecture documentation, decision logs, and system diagrams for the Reporium 
 
 | Metric | Value |
 |--------|-------|
-| Repos tracked | 826 |
+| Repos tracked | 1,898 |
 | Languages | 29 |
 | Public repos | 50+ |
 | Neon tables | 13 |

--- a/docs/10-append-only-embeddings.md
+++ b/docs/10-append-only-embeddings.md
@@ -1,5 +1,9 @@
 # 10 - Append-Only Embeddings
 
+**Status:** Accepted
+**Date:** 2026-04-09
+**Tracking:** KAN-103 (Knowledge Graph Data Trust epic)
+
 One decision about how we store vector embeddings for repos — switching from overwrite to history-preserving append-only rows.
 
 ---

--- a/docs/11-atomic-graph-rebuild.md
+++ b/docs/11-atomic-graph-rebuild.md
@@ -1,5 +1,9 @@
 # 11 - Atomic Graph Rebuild
 
+**Status:** Accepted
+**Date:** 2026-04-09
+**Tracking:** KAN-102 (Knowledge Graph Data Trust epic)
+
 One decision about how the knowledge graph is rebuilt — switching from delete-then-insert to a staging table swap with validation.
 
 ---

--- a/docs/12-ingest-runs-provenance.md
+++ b/docs/12-ingest-runs-provenance.md
@@ -1,5 +1,9 @@
 # 12 - Ingest Runs Provenance
 
+**Status:** Accepted
+**Date:** 2026-04-09
+**Tracking:** KAN-102 (Knowledge Graph Data Trust epic - provenance for atomic rebuild)
+
 One decision about what the `ingest_runs` table tracks — expanding it from a status log into a full provenance record for each ingestion.
 
 ---

--- a/docs/13-tag-canonicalization.md
+++ b/docs/13-tag-canonicalization.md
@@ -1,5 +1,9 @@
 # 13 - Tag Canonicalization
 
+**Status:** Accepted
+**Date:** 2026-04-09
+**Tracking:** KAN-104 (Knowledge Graph Data Trust epic)
+
 One decision about how integration tags from the AI enricher are normalized before they are used to build graph edges.
 
 ---

--- a/docs/14-repo-dependencies-as-depends-on.md
+++ b/docs/14-repo-dependencies-as-depends-on.md
@@ -1,5 +1,9 @@
 # 14 - Repo Dependencies as DEPENDS_ON
 
+**Status:** Accepted
+**Date:** 2026-04-09
+**Tracking:** KAN-100 (Knowledge Graph Data Trust epic)
+
 One decision about the source of truth for `DEPENDS_ON` edges in the knowledge graph — switching from description keyword matching to structured dependency extraction.
 
 ---

--- a/docs/15-phase-2-3-followups.md
+++ b/docs/15-phase-2-3-followups.md
@@ -1,6 +1,8 @@
 # Phase 2-3 Follow-ups
 
-Status: draft
+**Status:** Draft
+**Date:** 2026-04-12
+**Tracking:** KAN-120 (Knowledge Graph Data Trust epic - phase 2-3 follow-ups)
 
 This note captures the post-backfill decisions that should drive the next
 feature-completeness and scaling wave after Phase 1 observability lands.

--- a/docs/archive/16-mcp-http-bridge-and-workato-auth.md
+++ b/docs/archive/16-mcp-http-bridge-and-workato-auth.md
@@ -1,5 +1,9 @@
 # 16 - MCP HTTP Bridge and Workato Authentication Model
 
+**Status:** Archived
+**Date:** 2026-04-15
+**Tracking:** KAN-120 (teardown / archival)
+
 > **ARCHIVED 2026-05-20:** Workato access lost and the Cloud Run service `reporium-mcp-http` has been deleted.
 > The two-token auth scheme (`X-MCP-Token` outer, `X-App-Token` inner) is no longer in effect.
 > Document retained for historical reference; do not treat as current architecture.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,8 +1,70 @@
 """Tests for documentation completeness and structure."""
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+# Markdown inline link: [text](target). We only care about links whose target
+# points at a local Markdown file (ends in .md, optionally with a #anchor).
+_MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+# Per-decision ADR files live one-per-file in docs/ (and docs/archive/) and each
+# carries exactly one "## Decision N: ..." heading plus a metadata block. The
+# aggregate decision log (02) and narrative docs are intentionally excluded.
+_DECISION_HEADING = re.compile(r"^##\s+Decision\s+\d+\b", re.MULTILINE)
+
+# Current operating scale of the platform. The 826 figure is the historical
+# launch-era baseline and must not be presented as current state in the README.
+EXPECTED_REPO_COUNT = 1898
+STALE_REPO_COUNT = 826
+
+
+def _markdown_files():
+    """All tracked Markdown files: README + everything under docs/ (recursive)."""
+    files = [REPO_ROOT / "README.md"]
+    files.extend(sorted(DOCS_DIR.rglob("*.md")))
+    return files
+
+
+def _adr_files():
+    """Per-decision ADR files: any doc containing a '## Decision N:' heading.
+
+    These are the standalone decision records (docs/10..16 and docs/archive/*).
+    The aggregate decision log uses '## Decision N: Title' headings too, so it
+    is filtered out explicitly by filename.
+    """
+    adrs = []
+    for path in sorted(DOCS_DIR.rglob("*.md")):
+        if path.name == "02-decision-log.md":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if _DECISION_HEADING.search(text):
+            adrs.append(path)
+    return adrs
+
+
+def _platform_glance_block(readme: str) -> str:
+    """Return the text of the README 'Platform at a Glance' section."""
+    marker = "## Platform at a Glance"
+    start = readme.index(marker)
+    rest = readme[start + len(marker):]
+    nxt = rest.find("\n## ")
+    return rest if nxt == -1 else rest[:nxt]
+
+
+def _metadata_value(text: str, key: str):
+    """Return the value of a 'Key: value' metadata line, or None if absent.
+
+    Tolerates the common Markdown emphasis form ('**Key:** value'), leading
+    blockquote / list markers, and surrounding emphasis on the value itself.
+    """
+    pattern = rf"(?im)^\s*[*_>\- ]*{re.escape(key)}\s*[*_]*\s*:\s*(.+?)\s*$"
+    m = re.search(pattern, text)
+    if m is None:
+        return None
+    return m.group(1).strip().strip("*_` ").strip()
 
 EXPECTED_DOCS = [
     "01-platform-overview.md",
@@ -64,3 +126,123 @@ def test_decision_log_has_nine_decisions():
     decision_log = (REPO_ROOT / "docs" / "02-decision-log.md").read_text()
     for i in range(1, 10):
         assert f"## Decision {i}" in decision_log, f"Missing Decision {i}"
+
+
+# ---------------------------------------------------------------------------
+# Doc-lint: no dead internal links
+# ---------------------------------------------------------------------------
+
+
+def test_no_dead_internal_markdown_links():
+    """Every internal [text](*.md) link must resolve to a file on disk.
+
+    Anchors (#section) and query strings are stripped; only the file portion is
+    checked. External links (http/https/mailto) are ignored.
+    """
+    broken = []
+    for md_file in _markdown_files():
+        text = md_file.read_text(encoding="utf-8")
+        for target in _MD_LINK.findall(text):
+            target = target.strip()
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            # Strip anchor / query suffix; we only resolve the file path.
+            file_part = re.split(r"[#?]", target, maxsplit=1)[0]
+            if not file_part.endswith(".md"):
+                continue
+            resolved = (md_file.parent / file_part).resolve()
+            if not resolved.exists():
+                broken.append(f"{md_file.name} -> {target}")
+    assert not broken, "Dead internal links found: " + "; ".join(broken)
+
+
+# ---------------------------------------------------------------------------
+# Doc-lint: every Decision (ADR) carries Status / Date / KAN metadata
+# ---------------------------------------------------------------------------
+
+
+def test_decision_files_discovered():
+    """Sanity guard: the ADR discovery must actually find the per-decision docs.
+
+    Without this, an over-eager filter could silently make the metadata checks
+    below vacuous (passing because they iterate over an empty list).
+    """
+    adrs = _adr_files()
+    assert len(adrs) >= 7, f"Expected at least 7 ADR files, found {len(adrs)}: {[p.name for p in adrs]}"
+
+
+def test_every_decision_has_status_date_kan_headers():
+    """Each per-decision ADR must declare Status, Date, and a KAN tracking ref."""
+    missing = []
+    for adr in _adr_files():
+        text = adr.read_text(encoding="utf-8")
+        if _metadata_value(text, "Status") is None:
+            missing.append(f"{adr.name}: missing Status")
+        if _metadata_value(text, "Date") is None:
+            missing.append(f"{adr.name}: missing Date")
+        if not re.search(r"KAN-\d+", text):
+            missing.append(f"{adr.name}: missing KAN reference")
+    assert not missing, "ADR metadata gaps: " + "; ".join(missing)
+
+
+def test_decision_dates_are_iso_format():
+    """The Date header of each ADR must be an ISO YYYY-MM-DD value."""
+    bad = []
+    for adr in _adr_files():
+        text = adr.read_text(encoding="utf-8")
+        value = _metadata_value(text, "Date")
+        assert value is not None, f"{adr.name}: no Date header to validate"
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+            bad.append(f"{adr.name}: '{value}'")
+    assert not bad, "Non-ISO ADR dates: " + "; ".join(bad)
+
+
+def test_archived_decisions_are_marked():
+    """Any ADR living under docs/archive/ must be explicitly marked ARCHIVED.
+
+    The archive marker prevents a retired decision from being read as current
+    architecture.
+    """
+    archive_dir = DOCS_DIR / "archive"
+    if not archive_dir.exists():
+        return
+    unmarked = []
+    for adr in sorted(archive_dir.rglob("*.md")):
+        text = adr.read_text(encoding="utf-8")
+        if "ARCHIVED" not in text:
+            unmarked.append(adr.name)
+        elif (_metadata_value(text, "Status") or "").lower() != "archived":
+            unmarked.append(f"{adr.name} (no 'Status: Archived')")
+    assert not unmarked, "Archived ADRs not marked: " + "; ".join(unmarked)
+
+
+# ---------------------------------------------------------------------------
+# Doc-lint: README repo count is current, not the stale 826 baseline
+# ---------------------------------------------------------------------------
+
+
+def test_platform_at_a_glance_uses_current_repo_count():
+    """The 'Platform at a Glance' diagram must show the current repo count."""
+    readme = (REPO_ROOT / "README.md").read_text()
+    glance = _platform_glance_block(readme)
+    assert str(EXPECTED_REPO_COUNT) in glance.replace(",", ""), (
+        f"'Platform at a Glance' must reference current repo count {EXPECTED_REPO_COUNT}"
+    )
+    assert f"({STALE_REPO_COUNT} repos)" not in glance, (
+        f"'Platform at a Glance' still shows the stale '({STALE_REPO_COUNT} repos)' baseline"
+    )
+
+
+def test_live_stats_repo_count_matches_glance():
+    """README 'Live Stats' repos-tracked value must equal the glance count.
+
+    Both are current-state claims; they must not drift apart.
+    """
+    readme = (REPO_ROOT / "README.md").read_text()
+    m = re.search(r"\|\s*Repos tracked\s*\|\s*([\d,]+)", readme)
+    assert m is not None, "README Live Stats missing 'Repos tracked' row"
+    value = int(m.group(1).replace(",", ""))
+    assert value == EXPECTED_REPO_COUNT, (
+        f"Live Stats repos tracked is {value}, expected {EXPECTED_REPO_COUNT}"
+    )
+    assert value != STALE_REPO_COUNT, "Live Stats still reports the stale 826 baseline"


### PR DESCRIPTION
## What

Hardens the offline doc-lint suite in `tests/test_docs.py` and corrects the stale 826-repo current-state figures in the README. Closes #1 (docs anchored to 826 repos).

Docs/tests only. No code, no network, no infra. CI is offline, so the local pytest run below is the validation.

## New tests (7), all with real assertions (mutation-checked)

- `test_no_dead_internal_markdown_links` - parses every `[text](*.md)` link in README + `docs/**`, resolves it relative to the owning file, strips `#anchor`/`?query`, and asserts the target exists. External links are skipped.
- `test_decision_files_discovered` - sanity guard so the metadata checks below can never pass vacuously (asserts >= 7 per-decision ADRs are found).
- `test_every_decision_has_status_date_kan_headers` - every per-decision ADR (`docs/10-16`) must declare `Status`, `Date`, and a `KAN-NNN` tracking ref. Accepts the `**Key:** value` Markdown form.
- `test_decision_dates_are_iso_format` - each ADR `Date` must be `YYYY-MM-DD`.
- `test_archived_decisions_are_marked` - anything under `docs/archive/` must carry an `ARCHIVED` marker and `Status: Archived`.
- `test_platform_at_a_glance_uses_current_repo_count` / `test_live_stats_repo_count_matches_glance` - README "Platform at a Glance" and "Live Stats" repo counts must equal the current scale (1,898) and stay consistent with each other; explicitly rejects the stale 826.

## Doc changes to satisfy the new lint

- **README**: `826 -> 1,898` in *Platform at a Glance* and *Live Stats*. The 826 baseline is intentionally preserved as historical context in `docs/02-decision-log.md` and `docs/04-scale-analysis.md` (which already reports the post-826 production state).
- **docs/10-16**: added `Status` / `Date` / `Tracking` metadata blocks. Dates are taken from the authoring commits; KAN refs map to the Knowledge Graph Data Trust epic stories (KAN-100/102/103/104) and KAN-120 for the phase-2-3 follow-ups and the archived ADR 16, which is now marked `Status: Archived`.

## Validation (local, offline)

```
$ python -m pytest -q
..............                                                           [100%]
14 passed in 0.02s

$ python -m ruff check tests/test_docs.py
All checks passed!
```

Mutation-check evidence (each reverted afterward): injecting a broken README `.md` link, removing a KAN ref from an ADR, and reverting Live Stats to 826 each failed exactly the responsible test (3 failed, 11 passed), confirming the assertions have teeth.

## Out of scope

The 826 figures inside narrative/historical docs (`02`, `03`, `06`, `07`, `08`, `09`) are left as-is per issue #1's "keep historical context vs current operating state" guidance; this PR fixes only the README current-state surfaces and adds the guard.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
